### PR TITLE
Better vcxsrv install + uninstall script fixes

### DIFF
--- a/create-targz.sh
+++ b/create-targz.sh
@@ -64,7 +64,7 @@ cp pageant.exe $BUILDDIR/opt/pageant/
 mkdir -p $BUILDDIR/opt/vcxsrv
 mkdir vcxsrv
 wget -O vcxsrvinstaller.exe "${VCXSRVINSTALLER}"
-7z x vcxsrvinstaller.exe -ovcxsrv
+/usr/libexec/p7zip/7za x vcxsrvinstaller.exe -ovcxsrv
 cd vcxsrv
 zip -9 -r vcxsrv.zip *
 cp vcxsrv.zip $BUILDDIR/opt/vcxsrv

--- a/create-targz.sh
+++ b/create-targz.sh
@@ -12,6 +12,7 @@ KSFILE="https://raw.githubusercontent.com/WhitewaterFoundry/sig-cloud-instance-b
 EPELRPM="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 PAGEANTEXE="https://the.earth.li/~sgtatham/putty/latest/w64/pageant.exe"
 WEASELPAGEANT="https://github.com/vuori/weasel-pageant/releases/download/v1.3/weasel-pageant-1.3.zip"
+VCXSRVINSTALLER="https://sourceforge.net/projects/vcxsrv/files/vcxsrv/1.20.1.4/vcxsrv-64.1.20.1.4.installer.exe/download"
 
 #go to our temporary directory
 cd $TMPDIR
@@ -20,7 +21,7 @@ cd $TMPDIR
 sudo yum update
 
 #get livemedia-creator dependencies
-sudo yum install libvirt lorax virt-install libvirt-daemon-config-network libvirt-daemon-kvm libvirt-daemon-driver-qemu unzip wget -y
+sudo yum install libvirt lorax virt-install libvirt-daemon-config-network libvirt-daemon-kvm libvirt-daemon-driver-qemu unzip wget p7zip p7zip-full p7zip-rar -y
 
 #restart libvirtd for good measure
 sudo systemctl restart libvirtd
@@ -51,7 +52,17 @@ cp weasel-pageant-1.3/weasel-pageant $BUILDDIR/opt/pageant/
 wget -O pageant.exe "${PAGEANTEXE}"
 cp pageant.exe $BUILDDIR/opt/pageant/
 
-#set some environmental variables
+# download vcxsrv self-extracting executable, extract, zip again
+mkdir -p $BUILDDIR/opt/vcxsrv
+mkdir vcxsrv
+wget -O vcxsrvinstaller.exe "${VCXSRVINSTALLER}"
+7z x vcxsrvinstaller.exe -ovcxsrv
+cd vcxsrv
+zip -9 -r vcxsrv.zip *
+cp vcxsrv.zip $BUILDDIR/opt/vcxsrv
+cd ../
+
+# set some environmental variables
 sudo bash -c "echo 'export DISPLAY=:0' >> $BUILDDIR/etc/profile.d/wsl.sh"
 sudo bash -c "echo 'export LIBGL_ALWAYS_INDIRECT=1' >> $BUILDDIR/etc/profile.d/wsh.sh"
 sudo bash -c "echo 'export NO_AT_BRIDGE=1' >> $BUILDDIR/etc/profile.d/wsl.sh"
@@ -63,9 +74,6 @@ sudo cp $ORIGINDIR/linux_files/firstrun.sh $BUILDDIR/etc/profile.d/firstrun.sh
 
 mkdir -p $BUILDDIR/opt/pengwin
 sudo cp $ORIGINDIR/linux_files/uninstall.sh $BUILDDIR/opt/pengwin/uninstall.sh
-
-mkdir -p $BUILDDIR/opt/vcxsrv
-sudo cp $ORIGINDIR/linux_files/vcxsrv.zip $BUILDDIR/opt/vcxsrv
 
 #re-build our tar image
 cd $BUILDDIR

--- a/create-targz.sh
+++ b/create-targz.sh
@@ -7,6 +7,8 @@ ORIGINDIR=$(pwd)
 TMPDIR=$(mktemp -d)
 BUILDDIR=$(mktemp -d)
 
+P7ZIPRPM="https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/p7zip-16.02-10.el7.x86_64.rpm"
+P7ZIPPLUGINSRPM="https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/p7zip-plugins-16.02-10.el7.x86_64.rpm"
 BOOTISO="https://centos.mirror.constant.com/7.6.1810/os/x86_64/images/boot.iso"
 KSFILE="https://raw.githubusercontent.com/WhitewaterFoundry/sig-cloud-instance-build/master/docker/centos-7-x86_64.ks"
 EPELRPM="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
@@ -21,7 +23,14 @@ cd $TMPDIR
 sudo yum update
 
 #get livemedia-creator dependencies
-sudo yum install libvirt lorax virt-install libvirt-daemon-config-network libvirt-daemon-kvm libvirt-daemon-driver-qemu unzip wget p7zip p7zip-full p7zip-rar -y
+sudo yum install libvirt lorax virt-install libvirt-daemon-config-network libvirt-daemon-kvm libvirt-daemon-driver-qemu unzip wget -y
+
+# install 7zip
+wget -O p7zip.rpm "${P7ZIPRPM}"
+wget -O p7zip-plugins.rpm "${P7ZIPRPM}"
+
+sudo rpm -U --quiet p7zip.rpm
+sudo rpm -U --quiet p7zip-plugins.rpm
 
 #restart libvirtd for good measure
 sudo systemctl restart libvirtd

--- a/create-targz.sh
+++ b/create-targz.sh
@@ -27,10 +27,9 @@ sudo yum install libvirt lorax virt-install libvirt-daemon-config-network libvir
 
 # install 7zip
 wget -O p7zip.rpm "${P7ZIPRPM}"
-wget -O p7zip-plugins.rpm "${P7ZIPRPM}"
-
-sudo rpm -U --quiet p7zip.rpm
-sudo rpm -U --quiet p7zip-plugins.rpm
+wget -O p7zip-plugins.rpm "${P7ZIPPLUGINSRPM}"
+sudo rpm -U --quiet --force p7zip.rpm
+sudo rpm -U --quiet --force p7zip-plugins.rpm
 
 #restart libvirtd for good measure
 sudo systemctl restart libvirtd

--- a/create-targz.sh
+++ b/create-targz.sh
@@ -7,8 +7,6 @@ ORIGINDIR=$(pwd)
 TMPDIR=$(mktemp -d)
 BUILDDIR=$(mktemp -d)
 
-P7ZIPRPM="https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/p7zip-16.02-10.el7.x86_64.rpm"
-P7ZIPPLUGINSRPM="https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/p7zip-plugins-16.02-10.el7.x86_64.rpm"
 BOOTISO="https://centos.mirror.constant.com/7.6.1810/os/x86_64/images/boot.iso"
 KSFILE="https://raw.githubusercontent.com/WhitewaterFoundry/sig-cloud-instance-build/master/docker/centos-7-x86_64.ks"
 EPELRPM="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
@@ -25,11 +23,9 @@ sudo yum update
 #get livemedia-creator dependencies
 sudo yum install libvirt lorax virt-install libvirt-daemon-config-network libvirt-daemon-kvm libvirt-daemon-driver-qemu unzip wget -y
 
-# install 7zip
-wget -O p7zip.rpm "${P7ZIPRPM}"
-wget -O p7zip-plugins.rpm "${P7ZIPPLUGINSRPM}"
-sudo rpm -U --quiet --force p7zip.rpm
-sudo rpm -U --quiet --force p7zip-plugins.rpm
+# install 7zip + zip
+sudo yum install epel-release -y
+sudo yum install p7zip p7zip-plugins zip -y
 
 #restart libvirtd for good measure
 sudo systemctl restart libvirtd
@@ -64,7 +60,7 @@ cp pageant.exe $BUILDDIR/opt/pageant/
 mkdir -p $BUILDDIR/opt/vcxsrv
 mkdir vcxsrv
 wget -O vcxsrvinstaller.exe "${VCXSRVINSTALLER}"
-/usr/libexec/p7zip/7za x vcxsrvinstaller.exe -ovcxsrv
+7z x vcxsrvinstaller.exe -ovcxsrv
 cd vcxsrv
 zip -9 -r vcxsrv.zip *
 cp vcxsrv.zip $BUILDDIR/opt/vcxsrv

--- a/linux_files/uninstall.sh
+++ b/linux_files/uninstall.sh
@@ -48,7 +48,7 @@ sudo rm -f /etc/profile.d/pageant.sh
 echo "Removing pageant.exe startup registry key"
 cat << EOF >> "${TMPDIR}/Uninstall.reg"
 Windows Registry Editor Version 5.00
-[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run\Pageant]
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run]
 "Pageant"=-
 EOF
 cp "${TMPDIR}/Uninstall.reg" "$HomeDrive$(cmd.exe /C 'echo %TEMP%' 2>&1 | tr -d '\r' | sed 's|\\|\/|g' | sed 's|.\:||g')"

--- a/linux_files/uninstall.sh
+++ b/linux_files/uninstall.sh
@@ -48,7 +48,8 @@ sudo rm -f /etc/profile.d/pageant.sh
 echo "Removing pageant.exe startup registry key"
 cat << EOF >> "${TMPDIR}/Uninstall.reg"
 Windows Registry Editor Version 5.00
-[-HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run\Pageant]
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run\Pageant]
+"Pageant"=-
 EOF
 cp "${TMPDIR}/Uninstall.reg" "$HomeDrive$(cmd.exe /C 'echo %TEMP%' 2>&1 | tr -d '\r' | sed 's|\\|\/|g' | sed 's|.\:||g')"
 cmd.exe /C "Reg import %TEMP%\Uninstall.reg"


### PR DESCRIPTION
Sets create-targz to install p7zip and zip, download the vcxsrv installer executable and unzip it to a folder, then zip the contents of that folder into a zip file to bundle in our rootfs image.

Also fixes the uninstall script so that the pageant registry is correctly deleted now.