### PR TITLE
Fix weaselpageant perms

### DIFF
--- a/create-targz.sh
+++ b/create-targz.sh
@@ -87,7 +87,6 @@ tar --ignore-failed-read -czvf $ORIGINDIR/install.tar.gz *
 cd $ORIGINDIR
 
 #clean up
-sudo umount $BUILDDIR/dev
 sudo rm -r $BUILDDIR
 sudo rm -r $TMPDIR
 sudo rm /tmp/install.iso

--- a/create-targz.sh
+++ b/create-targz.sh
@@ -10,7 +10,7 @@ BUILDDIR=$(mktemp -d)
 BOOTISO="https://centos.mirror.constant.com/7.6.1810/os/x86_64/images/boot.iso"
 KSFILE="https://raw.githubusercontent.com/WhitewaterFoundry/sig-cloud-instance-build/master/docker/centos-7-x86_64.ks"
 EPELRPM="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-PAGEANTEXE="https://the.earth.li/~sgtatham/putty/latest/w64/pageant.exe"
+PAGEANTEXE="https://github.com/NoMoreFood/putty-cac/raw/0.71/binaries/x64/pageant.exe"
 WEASELPAGEANT="https://github.com/vuori/weasel-pageant/releases/download/v1.3/weasel-pageant-1.3.zip"
 VCXSRVINSTALLER="https://sourceforge.net/projects/vcxsrv/files/vcxsrv/1.20.1.4/vcxsrv-64.1.20.1.4.installer.exe/download"
 

--- a/linux_files/firstrun.sh
+++ b/linux_files/firstrun.sh
@@ -51,7 +51,7 @@ rm -rf "${TMPDIR}"
 # NOTE: putting eval in a string like this is necessary to avoid bash executing it during
 # 	running of firstrun.sh
 echo "Configuring weasel-pageant WSL integration"
-string="eval \$(\""${Home}/.pageant/weasel-pageant"\" -r --helper \"${Home}/.pageant\")"
+string="eval \$(\""${Home}/.pageant/weasel-pageant"\" -r)"
 sudo bash -c 'cat > /etc/profile.d/pageant.sh' << EOF
 #!/bin/bash
 $string

--- a/linux_files/firstrun.sh
+++ b/linux_files/firstrun.sh
@@ -29,6 +29,7 @@ if [[ ! -d "${Home}/.pageant"  ]] ; then
 	mkdir "${Home}/.pageant"
 	cp /opt/pageant/* "${Home}/.pageant"
 	chmod +x "${Home}/.pageant/weasel-pageant"
+	chmod +x "${Home}/.pageant/helper.exe"
 else
         echo "${Home}/.pageant already exists, leaving in place."
         echo "To reinstall pageant and other features, run /opt/pengwin/uninstall.sh then move /opt/pengwin/firstrun.sh to /etc/profile.d/"


### PR DESCRIPTION
Fixes the weasel-pageant win32 helper executable permissions so it can be successfully launched by weasel-pageant.

Please note this is built from the branch in PR #43 so once that has gone through I'll set this PR as ready to merge.