### PR TITLE
Nnl term variable change

### DIFF
--- a/create-targz.sh
+++ b/create-targz.sh
@@ -70,7 +70,7 @@ cd ../
 sudo bash -c "echo 'export DISPLAY=:0' >> $BUILDDIR/etc/profile.d/wsl.sh"
 sudo bash -c "echo 'export LIBGL_ALWAYS_INDIRECT=1' >> $BUILDDIR/etc/profile.d/wsl.sh"
 sudo bash -c "echo 'export NO_AT_BRIDGE=1' >> $BUILDDIR/etc/profile.d/wsl.sh"
-sudo bash -c "echo 'export TERM=xterm-color' >> $BUILDDIR/etc/profile.d/term-fix.sh"
+sudo bash -c "echo 'export TERM=xterm-color' >> $BUILDDIR/etc/profile.d/00-fix-term.sh"
 
 # Copy over our own files
 sudo cp $ORIGINDIR/linux_files/wsl.conf $BUILDDIR/etc/wsl.conf

--- a/create-targz.sh
+++ b/create-targz.sh
@@ -70,7 +70,7 @@ cd ../
 sudo bash -c "echo 'export DISPLAY=:0' >> $BUILDDIR/etc/profile.d/wsl.sh"
 sudo bash -c "echo 'export LIBGL_ALWAYS_INDIRECT=1' >> $BUILDDIR/etc/profile.d/wsl.sh"
 sudo bash -c "echo 'export NO_AT_BRIDGE=1' >> $BUILDDIR/etc/profile.d/wsl.sh"
-sudo bash -c "echo 'export TERM=xterm-color' >> $BUILDDIR/etc/profile.d/00-fix-term.sh"
+sudo bash -c "echo 'export TERM=st-256color' >> $BUILDDIR/etc/profile.d/00-fix-term.sh"
 
 # Copy over our own files
 sudo cp $ORIGINDIR/linux_files/wsl.conf $BUILDDIR/etc/wsl.conf

--- a/create-targz.sh
+++ b/create-targz.sh
@@ -70,7 +70,7 @@ cd ../
 sudo bash -c "echo 'export DISPLAY=:0' >> $BUILDDIR/etc/profile.d/wsl.sh"
 sudo bash -c "echo 'export LIBGL_ALWAYS_INDIRECT=1' >> $BUILDDIR/etc/profile.d/wsl.sh"
 sudo bash -c "echo 'export NO_AT_BRIDGE=1' >> $BUILDDIR/etc/profile.d/wsl.sh"
-sudo bash -c "echo 'export TERM=st-256color' >> $BUILDDIR/etc/profile.d/00-fix-term.sh"
+sudo bash -c "echo 'export TERM=st-256color' >> $BUILDDIR/etc/profile.d/wsl.sh"
 
 # Copy over our own files
 sudo cp $ORIGINDIR/linux_files/wsl.conf $BUILDDIR/etc/wsl.conf

--- a/create-targz.sh
+++ b/create-targz.sh
@@ -70,6 +70,7 @@ cd ../
 sudo bash -c "echo 'export DISPLAY=:0' >> $BUILDDIR/etc/profile.d/wsl.sh"
 sudo bash -c "echo 'export LIBGL_ALWAYS_INDIRECT=1' >> $BUILDDIR/etc/profile.d/wsl.sh"
 sudo bash -c "echo 'export NO_AT_BRIDGE=1' >> $BUILDDIR/etc/profile.d/wsl.sh"
+sudo bash -c "echo 'export TERM=xterm-color' >> $BUILDDIR/etc/profile.d/term-fix.sh"
 
 # Copy over our own files
 sudo cp $ORIGINDIR/linux_files/wsl.conf $BUILDDIR/etc/wsl.conf


### PR DESCRIPTION
Changes TERM environment variable to `st-256color` to help mitigate issues with nano text-overflow, vim colours and other issues that seem to occur under default `xterm-256color` and other variables.